### PR TITLE
feat(iam): add TerraformDeploymentRole with scoped trust policy for T…

### DIFF
--- a/Infra/attachments.tf
+++ b/Infra/attachments.tf
@@ -35,3 +35,24 @@ resource "aws_iam_role_policy_attachment" "step_trigger_exec" {
   role       = aws_iam_role.StepFunctionTriggerRole.name
   policy_arn = aws_iam_policy.stepfunctions_exec.arn
 }
+
+resource "aws_iam_role_policy_attachment" "terraform_kms_attach" {
+  role       = aws_iam_role.TerraformDeploymentRole.name
+  policy_arn = aws_iam_policy.terraform_kms_provision.arn
+}
+
+resource "aws_iam_role_policy_attachment" "terraform_apigateway_attach" {
+  role       = aws_iam_role.TerraformDeploymentRole.name
+  policy_arn = aws_iam_policy.terraform_apigateway_provision.arn
+}
+
+resource "aws_iam_role_policy_attachment" "terraform_iam_attach" {
+  role       = aws_iam_role.TerraformDeploymentRole.name
+  policy_arn = aws_iam_policy.terraform_iam_provision.arn
+}
+
+resource "aws_iam_role_policy_attachment" "terraform_s3_attach" {
+  role       = aws_iam_role.TerraformDeploymentRole.name
+  policy_arn = aws_iam_policy.terraform_s3_provision.arn
+}
+

--- a/Infra/polices.tf
+++ b/Infra/polices.tf
@@ -25,6 +25,96 @@ resource "aws_iam_policy" "order_table_access" {
   })
 }
 
+resource "aws_iam_policy" "terraform_kms_provision" {
+  name        = "${var.project_name}-${var.environment}-TerraformKMSProvision"
+  description = "Allow Terraform to create and tag KMS keys"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "kms:CreateKey",
+          "kms:TagResource",
+          "kms:PutKeyPolicy",
+          "kms:EnableKeyRotation",
+          "kms:DescribeKey"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "terraform_apigateway_provision" {
+  name        = "${var.project_name}-${var.environment}-TerraformAPIGatewayProvision"
+  description = "Allow Terraform to create and tag API Gateway resources"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "apigateway:POST",
+          "apigateway:PUT",
+          "apigateway:GET",
+          "apigateway:DELETE"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "terraform_iam_provision" {
+  name        = "${var.project_name}-${var.environment}-TerraformIAMProvision"
+  description = "Allow Terraform to create IAM roles and policies"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "iam:CreateRole",
+          "iam:AttachRolePolicy",
+          "iam:PassRole",
+          "iam:DeleteRole",
+          "iam:GetRole",
+          "iam:CreatePolicy",
+          "iam:DeletePolicy"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "terraform_s3_provision" {
+  name        = "${var.project_name}-${var.environment}-TerraformS3Provision"
+  description = "Allow Terraform to create and configure S3 buckets"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:CreateBucket",
+          "s3:PutBucketPolicy",
+          "s3:PutBucketTagging",
+          "s3:PutEncryptionConfiguration",
+          "s3:GetBucketLocation"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+
 resource "aws_iam_policy" "lambda_control" {
 name        = "AllowLambdaOperations"
   description = "Policy to allow operations on Lambda functions"

--- a/Infra/roles.tf
+++ b/Infra/roles.tf
@@ -20,6 +20,8 @@ resource "aws_iam_role" "LambdaExecutionRole" {
   })
 }
 
+
+
 resource "aws_iam_role" "StepFunctionTriggerRole" {
   name = "${var.project_name}-${var.environment}-StepFunctionTriggerRole"
 
@@ -38,4 +40,28 @@ resource "aws_iam_role" "StepFunctionTriggerRole" {
       Action = "sts:AssumeRole"
     }]
   })
+
 }
+
+resource "aws_iam_role" "TerraformDeploymentRole" {
+  name = "${var.project_name}-${var.environment}-TerraformDeploymentRole"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          AWS = "arn:aws:iam::${var.account_id}:role/TerraformOperatorRole"
+        },
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = {
+    Environment = var.environment
+    Project     = var.project_name
+  }
+}
+

--- a/Infra/s3.tf
+++ b/Infra/s3.tf
@@ -1,7 +1,7 @@
 // S3 bucket for invoice storage
 // Stores generated invoices and applies lifecycle rules for retention
 resource "aws_s3_bucket" "invoice_storage_ofp" {
-    bucket = "invoicestorage-ofp"
+    bucket = "invoicestorage-ofp-${var.project_name}"
     lifecycle {
         prevent_destroy = true
     }

--- a/Infra/variables.tf
+++ b/Infra/variables.tf
@@ -3,6 +3,13 @@ variable "region" {
   type = string
   description = "AWS region for deployment"
 }
+
+variable "account_id" {
+  description = "AWS Account ID used for constructing ARNs"
+  type        = string
+}
+
+
 variable "environment" {
   type    = string
   default = "dev"


### PR DESCRIPTION
…erraformOperatorRole

- Introduced TerraformDeploymentRole to support secure infrastructure provisioning
- Used variable-based account ID for flexible ARN construction
- Updated trust policy to allow assumption by TerraformOperatorRole
- Avoided hardcoded user references for better portability and security